### PR TITLE
release: magelib v0.7.0

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
       - main
       - release-*
 
+permissions:
+  contents: write
+
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Updates release workflow to allow write permissions. As an optimization,
we also only build gotagger, rather than all of the tools.