### PR TITLE
ci: enable grouped dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,17 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      gomod:
+        update-types:
+          - minor
+          - patch
   - package-ecosystem: github-actions
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      github-actions:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Should reduce the churn caused by dependabot PRs.